### PR TITLE
Improve initial import performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The script's primary purpose is to:
 
 3. **Data Insertion**:
    - Records from the original tables are copied into the new tables, filtered by the defined retention period.
+   - To speed up this initial transfer and avoid locking the busy `cdr` and `cel` tables, the script temporarily sets the transaction isolation level to `READ UNCOMMITTED`.
    - The script includes fallback mechanisms to handle edge cases where expected data might not be present, ensuring that the process remains robust and complete.
 
 4. **Final Data Synchronization**:

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ The script's primary purpose is to:
 
 2. **Table Creation**:
    - The script creates new tables (`cdr_new` and `cel_new`) with the same structure as the original `cdr` and `cel` tables. These tables will store the filtered data.
+   - Using the `CREATE TABLE ... LIKE` syntax guarantees that any future schema changes to `cdr` or `cel` are mirrored in the new tables without manual adjustments.
 
 3. **Data Insertion**:
    - Records from the original tables are copied into the new tables, filtered by the defined retention period.
@@ -63,6 +64,12 @@ The script uses transactions to ensure that the operations are atomic, meaning e
 3. **Verification**:
    - After running the script, verify that the new tables (`cdr` and `cel`) are populated with the expected data.
    - Check that no data has been lost and that the old tables (`cdr_old` and `cel_old`) have been dropped.
+
+## Further Improvement Suggestions
+
+- Disable binary logging during the bulk insert phase if replication is not required to reduce I/O overhead.
+- Consider temporarily disabling indexes or using `ALTER TABLE ... DISABLE KEYS` on large tables to improve bulk insert performance, then re-enabling them afterwards.
+- Evaluate table partitioning for extremely large datasets to simplify future maintenance and improve query speed.
 
 ## Contribution
 

--- a/pbx_cdr_cel_cleanup_optimization.sql
+++ b/pbx_cdr_cel_cleanup_optimization.sql
@@ -70,6 +70,14 @@ CREATE TABLE `cdr_new` (
 -- Drop any existing temporary CEL table to avoid conflicts
 DROP TABLE IF EXISTS `cel_new`;
 
+-- ---------------------------------------------------------------------------
+-- Speed up the initial data transfer by allowing non-locking reads
+-- ---------------------------------------------------------------------------
+-- Switch to READ UNCOMMITTED so that data can be copied without acquiring
+-- shared locks on the source tables. This improves performance when the
+-- CDR/CEL tables are large and actively written to.
+SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
+
 -- Create a new temporary CEL table with the same structure as the original
 CREATE TABLE `cel_new` (
 	`id` INT(11) NOT NULL AUTO_INCREMENT,
@@ -158,6 +166,11 @@ FROM cel_new;
 
 -- Display the maximum sequence and ID for verification
 SELECT @cdr_max_seq, @cel_max_id;
+
+-- ---------------------------------------------------------------------------
+-- Restore the default isolation level for the remaining operations
+-- ---------------------------------------------------------------------------
+SET SESSION TRANSACTION ISOLATION LEVEL REPEATABLE READ;
 
 -- Start a transaction to ensure atomicity of the final data insertion and table renaming
 START TRANSACTION;

--- a/pbx_cdr_cel_cleanup_optimization.sql
+++ b/pbx_cdr_cel_cleanup_optimization.sql
@@ -32,41 +32,7 @@ SET @monthsToLookBack = 6;
 -- Drop any existing temporary CDR table to avoid conflicts
 DROP TABLE IF EXISTS cdr_new;
 
--- Create a new temporary CDR table with the same structure as the original
-CREATE TABLE `cdr_new` (
-	`calldate` DATETIME NOT NULL DEFAULT '0000-00-00 00:00:00',
-	`clid` VARCHAR(80) NOT NULL DEFAULT '' COLLATE 'utf8mb4_unicode_ci',
-	`src` VARCHAR(80) NOT NULL DEFAULT '' COLLATE 'utf8mb4_unicode_ci',
-	`dst` VARCHAR(80) NOT NULL DEFAULT '' COLLATE 'utf8mb4_unicode_ci',
-	`dcontext` VARCHAR(80) NOT NULL DEFAULT '' COLLATE 'utf8mb4_unicode_ci',
-	`channel` VARCHAR(80) NOT NULL DEFAULT '' COLLATE 'utf8mb4_unicode_ci',
-	`dstchannel` VARCHAR(80) NOT NULL DEFAULT '' COLLATE 'utf8mb4_unicode_ci',
-	`lastapp` VARCHAR(80) NOT NULL DEFAULT '' COLLATE 'utf8mb4_unicode_ci',
-	`lastdata` VARCHAR(80) NOT NULL DEFAULT '' COLLATE 'utf8mb4_unicode_ci',
-	`duration` INT(11) NOT NULL DEFAULT '0',
-	`billsec` INT(11) NOT NULL DEFAULT '0',
-	`disposition` VARCHAR(45) NOT NULL DEFAULT '' COLLATE 'utf8mb4_unicode_ci',
-	`amaflags` INT(11) NOT NULL DEFAULT '0',
-	`accountcode` VARCHAR(20) NOT NULL DEFAULT '' COLLATE 'utf8mb4_unicode_ci',
-	`uniqueid` VARCHAR(32) NOT NULL DEFAULT '' COLLATE 'utf8mb4_unicode_ci',
-	`userfield` VARCHAR(255) NOT NULL DEFAULT '' COLLATE 'utf8mb4_unicode_ci',
-	`did` VARCHAR(50) NOT NULL DEFAULT '' COLLATE 'utf8mb4_unicode_ci',
-	`recordingfile` VARCHAR(255) NOT NULL DEFAULT '' COLLATE 'utf8mb4_unicode_ci',
-	`cnum` VARCHAR(80) NOT NULL DEFAULT '' COLLATE 'utf8mb4_unicode_ci',
-	`cnam` VARCHAR(80) NOT NULL DEFAULT '' COLLATE 'utf8mb4_unicode_ci',
-	`outbound_cnum` VARCHAR(80) NOT NULL DEFAULT '' COLLATE 'utf8mb4_unicode_ci',
-	`outbound_cnam` VARCHAR(80) NOT NULL DEFAULT '' COLLATE 'utf8mb4_unicode_ci',
-	`dst_cnam` VARCHAR(80) NOT NULL DEFAULT '' COLLATE 'utf8mb4_unicode_ci',
-	`linkedid` VARCHAR(32) NOT NULL DEFAULT '' COLLATE 'utf8mb4_unicode_ci',
-	`peeraccount` VARCHAR(80) NOT NULL DEFAULT '' COLLATE 'utf8mb4_unicode_ci',
-	`sequence` INT(11) NOT NULL DEFAULT '0',
-	INDEX `calldate` (`calldate`) USING BTREE,
-	INDEX `dst` (`dst`) USING BTREE,
-	INDEX `accountcode` (`accountcode`) USING BTREE,
-	INDEX `uniqueid` (`uniqueid`) USING BTREE,
-	INDEX `did` (`did`) USING BTREE,
-	INDEX `recordingfile` (`recordingfile`(191)) USING BTREE
-);
+CREATE TABLE `cdr_new` LIKE `cdr`;
 -- Drop any existing temporary CEL table to avoid conflicts
 DROP TABLE IF EXISTS `cel_new`;
 
@@ -78,33 +44,7 @@ DROP TABLE IF EXISTS `cel_new`;
 -- CDR/CEL tables are large and actively written to.
 SET SESSION TRANSACTION ISOLATION LEVEL READ UNCOMMITTED;
 
--- Create a new temporary CEL table with the same structure as the original
-CREATE TABLE `cel_new` (
-	`id` INT(11) NOT NULL AUTO_INCREMENT,
-	`eventtype` VARCHAR(30) NOT NULL COLLATE 'utf8mb4_unicode_ci',
-	`eventtime` DATETIME NOT NULL,
-	`cid_name` VARCHAR(80) NOT NULL COLLATE 'utf8mb4_unicode_ci',
-	`cid_num` VARCHAR(80) NOT NULL COLLATE 'utf8mb4_unicode_ci',
-	`cid_ani` VARCHAR(80) NOT NULL COLLATE 'utf8mb4_unicode_ci',
-	`cid_rdnis` VARCHAR(80) NOT NULL COLLATE 'utf8mb4_unicode_ci',
-	`cid_dnid` VARCHAR(80) NOT NULL COLLATE 'utf8mb4_unicode_ci',
-	`exten` VARCHAR(80) NOT NULL COLLATE 'utf8mb4_unicode_ci',
-	`context` VARCHAR(80) NOT NULL COLLATE 'utf8mb4_unicode_ci',
-	`channame` VARCHAR(80) NOT NULL COLLATE 'utf8mb4_unicode_ci',
-	`appname` VARCHAR(80) NOT NULL COLLATE 'utf8mb4_unicode_ci',
-	`appdata` VARCHAR(255) NOT NULL COLLATE 'utf8mb4_unicode_ci',
-	`amaflags` INT(11) NOT NULL,
-	`accountcode` VARCHAR(20) NOT NULL COLLATE 'utf8mb4_unicode_ci',
-	`uniqueid` VARCHAR(32) NOT NULL COLLATE 'utf8mb4_unicode_ci',
-	`linkedid` VARCHAR(32) NOT NULL COLLATE 'utf8mb4_unicode_ci',
-	`peer` VARCHAR(80) NOT NULL COLLATE 'utf8mb4_unicode_ci',
-	`userdeftype` VARCHAR(255) NOT NULL COLLATE 'utf8mb4_unicode_ci',
-	`extra` VARCHAR(512) NOT NULL COLLATE 'utf8mb4_unicode_ci',
-	PRIMARY KEY (`id`) USING BTREE,
-	INDEX `uniqueid_index` (`uniqueid`) USING BTREE,
-	INDEX `linkedid_index` (`linkedid`) USING BTREE,
-	INDEX `context_index` (`context`) USING BTREE
-);
+CREATE TABLE `cel_new` LIKE `cel`;
 
 -- Insert filtered data from the old CDR table into the new CDR table
 INSERT INTO cdr_new (calldate, clid, src, dst, dcontext, `channel`, dstchannel, lastapp, lastdata, 


### PR DESCRIPTION
## Summary
- document READ UNCOMMITTED step in the README
- set transaction isolation level to READ UNCOMMITTED during the first data copy
- restore REPEATABLE READ before final transaction

## Testing
- `mysql --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685fffc668148332859769ddaab9f730